### PR TITLE
Make Create Checkout options deeply partial

### DIFF
--- a/src/modules/checkout/checkout.types.ts
+++ b/src/modules/checkout/checkout.types.ts
@@ -121,11 +121,11 @@ export interface LemonsqueezyCheckout {
      * @docs https://docs.lemonsqueezy.com/help/checkout/prefilling-checkout-fields
      * @docs https://docs.lemonsqueezy.com/help/checkout/passing-custom-data
      */
-    checkout_data: LemonsqueezyCheckoutData;
+    checkout_data: Partial<LemonsqueezyCheckoutData>;
     /**
      * An object containing checkout options for this checkout
      */
-    checkout_options: LemonsqueezyCheckoutOptions;
+    checkout_options: Partial<LemonsqueezyCheckoutOptions>;
     /**
      * An ISO-8601 formatted date-time string indicating when the object was created
      *
@@ -147,7 +147,7 @@ export interface LemonsqueezyCheckout {
     /**
      * An object containing any overridden product options for this checkout
      */
-    product_options: LemonsqueezyProductOptions;
+    product_options: Partial<LemonsqueezyProductOptions>;
     /**
      * The ID of the store this checkout belongs to
      */


### PR DESCRIPTION
Hi.
first of all, thank you for this package! It saved me a lot of time. 

When I was implementing the createCheckout method I noticed that all the sub-attributes of LemonsqueezyCheckout.attributes which are product_options, checkout_options and checkout_data were required. But this isn't the case for the API which sub-attributes of these objects are all optional. 

For example, if I just want to set custom data in checkout_data like this:
```
{
  checkout_data:{
     custom: {
       user_id = "blablabla"
     }
  }
}
```

I can't achieve this since the sub-types were non-partial. I was forced to fill in email, name, billing_address... etc columns.

By making these sub-types partial I believe I have fixed this and all tests passed 