### PR TITLE
Fix create checkout logic

### DIFF
--- a/src/modules/checkout/checkout.action.ts
+++ b/src/modules/checkout/checkout.action.ts
@@ -21,7 +21,7 @@ import type { SharedModuleOptions } from "~/shared";
  * @returns A checkout object
  */
 export async function createCheckout(
-  options: CreateCheckoutOptions & SharedModuleOptions
+  options: CreateCheckoutOptions & Pick<SharedModuleOptions, "apiKey">
 ): Promise<CreateCheckoutResult> {
   const {
     checkout_data,
@@ -45,20 +45,18 @@ export async function createCheckout(
           product_options,
         },
         relationships: {
-          ...(store
-            ? {
-                store: {
-                  data: { id: store, type: LemonsqueezyDataType.stores },
-                },
-              }
-            : {}),
-          ...(variant
-            ? {
-                variant: {
-                  data: { id: variant, type: LemonsqueezyDataType.variants },
-                },
-              }
-            : {}),
+          store: {
+            data: {
+              id: store,
+              type: LemonsqueezyDataType.stores,
+            },
+          },
+          variant: {
+            data: {
+              id: variant,
+              type: LemonsqueezyDataType.variants,
+            },
+          },
         },
         type: LemonsqueezyDataType.checkouts,
       },

--- a/src/modules/checkout/checkout.action.ts
+++ b/src/modules/checkout/checkout.action.ts
@@ -1,6 +1,7 @@
-import { requestLemonSqueeze } from "~/shared";
+import { LemonsqueezyDataType, requestLemonSqueeze } from "~/shared";
 
 import type {
+  CreateCheckoutBody,
   CreateCheckoutOptions,
   CreateCheckoutResult,
   ListAllCheckoutsOptions,
@@ -28,16 +29,39 @@ export async function createCheckout(
     custom_price,
     expires_at,
     product_options,
+    store,
+    variant,
     ...rest
   } = options;
 
-  return requestLemonSqueeze<CreateCheckoutResult>({
+  return requestLemonSqueeze<CreateCheckoutResult, CreateCheckoutBody>({
     data: {
-      ...(checkout_data ? { checkout_data } : {}),
-      ...(checkout_options ? { checkout_options } : {}),
-      ...(custom_price ? { custom_price } : {}),
-      ...(expires_at ? { expires_at } : {}),
-      ...(product_options ? { product_options } : {}),
+      data: {
+        attributes: {
+          checkout_data,
+          checkout_options,
+          custom_price,
+          expires_at,
+          product_options,
+        },
+        relationships: {
+          ...(store
+            ? {
+                store: {
+                  data: { id: store, type: LemonsqueezyDataType.stores },
+                },
+              }
+            : {}),
+          ...(variant
+            ? {
+                variant: {
+                  data: { id: variant, type: LemonsqueezyDataType.variants },
+                },
+              }
+            : {}),
+        },
+        type: LemonsqueezyDataType.checkouts,
+      },
     },
     path: "/checkouts",
     method: "POST",

--- a/src/modules/checkout/checkout.test.ts
+++ b/src/modules/checkout/checkout.test.ts
@@ -1,19 +1,21 @@
 import { describe, it, expect, beforeAll } from "vitest";
+import { email, firstName, name, zipCode } from "minifaker";
+import "minifaker/locales/en";
 
-import { listAllCheckouts } from ".";
+import { createCheckout, listAllCheckouts, retrieveCheckout } from ".";
+import { listAllStores, listAllVariants } from "..";
 
-describe.concurrent("Checkout", () => {
+import type { CreateCheckoutResult } from ".";
+
+describe("Checkout", () => {
   const apiKey = process.env.LEMON_SQUEEZY_API_KEY as string;
+  let newCheckout: CreateCheckoutResult;
 
   beforeAll(() => {
     if (!apiKey) throw "No LEMON_SQUEEZY_API_KEY environment variable found";
   });
 
-  it("Retrieve checkout", async () => {
-    expect(true).toEqual(true);
-  });
-
-  it("List all checkouts", async () => {
+  it.concurrent("List all checkouts", async () => {
     const checkouts = await listAllCheckouts({
       apiKey,
     });
@@ -21,5 +23,66 @@ describe.concurrent("Checkout", () => {
     expect(checkouts).toBeDefined();
     expect(Array.isArray(checkouts.data)).toBe(true);
     expect(checkouts.errors).toBeUndefined();
+  });
+
+  it("Create a checkout", async () => {
+    if (newCheckout)
+      throw new Error(
+        "`newCheckout` is already initialised before a new checkout has been created."
+      );
+
+    const [stores, variants] = await Promise.all([
+      listAllStores({
+        apiKey,
+      }),
+      listAllVariants({
+        apiKey,
+      }),
+    ]);
+
+    newCheckout = await createCheckout({
+      apiKey,
+      checkout_data: {
+        billing_address: {
+          country: "US",
+          zip: zipCode(),
+        },
+        email: email(),
+        name: name(),
+      },
+      custom_price: 100000,
+      product_options: {
+        description: "Hello World",
+        name: firstName(),
+        receipt_button_text: "Buy now",
+        receipt_link_url: "https://lemonsqueezy.com",
+        receipt_thank_you_note: "Thank you for your purchase",
+        redirect_url: "https://lemonsqueezy.com",
+      },
+      store: stores.data.at(0)!.id,
+      variant: variants.data.at(0)!.id,
+    });
+
+    expect(newCheckout).toBeDefined();
+    expect(newCheckout.data).toBeDefined();
+    expect(newCheckout.data).not.toBeNull();
+    expect(newCheckout.errors).toBeUndefined();
+  });
+
+  it("Retrieve checkout", async () => {
+    if (!newCheckout)
+      throw new Error(
+        "`newCheckout` is not defined. Check the `Create a checkout` test has run first."
+      );
+
+    const checkout = await retrieveCheckout({
+      apiKey,
+      id: newCheckout.data.id,
+    });
+
+    expect(checkout).toBeDefined();
+    expect(checkout.data).toBeDefined();
+    expect(checkout.data).not.toBeNull();
+    expect(checkout.errors).toBeUndefined();
   });
 });

--- a/src/modules/checkout/checkout.types.ts
+++ b/src/modules/checkout/checkout.types.ts
@@ -239,7 +239,7 @@ export interface CreateCheckoutOptions extends SharedLemonsqueezyOptions {
   /**
    * The ID of the store this checkout belongs to.
    */
-  store: number;
+  store: string;
   /**
    * The ID of the variant associated with this checkout.
    *
@@ -248,7 +248,7 @@ export interface CreateCheckoutOptions extends SharedLemonsqueezyOptions {
    * the `product_options.enabled_variants` option to determine which variant(s) are
    * displayed in the checkout.
    */
-  variant: number;
+  variant: string;
 }
 
 export interface CreateCheckoutBody {

--- a/src/modules/checkout/checkout.types.ts
+++ b/src/modules/checkout/checkout.types.ts
@@ -23,11 +23,11 @@ export interface LemonsqueezyCheckoutData {
   /**
    * An object containing any custom data to be passed to the checkout
    */
-  custom: Array<any>;
+  custom?: Array<any>;
   /**
    * A pre-filled discount code
    */
-  discount_code: string;
+  discount_code?: string;
   /**
    * A pre-filled email address
    */
@@ -39,40 +39,57 @@ export interface LemonsqueezyCheckoutData {
   /**
    * A pre-filled tax number
    */
-  tax_number: string;
+  tax_number?: string;
 }
 
 export interface LemonsqueezyCheckoutOptions {
   /**
    * A custom hex color to use for the checkout button
    */
-  button_color: `#${string}`;
+  button_color?: `#${string}`;
   /**
    * If `true`, use the dark theme
    */
-  dark: boolean;
+  dark?: boolean;
   /**
    * If `false`, hide the product description
    */
-  desc: boolean;
+  desc?: boolean;
   /**
    * If `false`, hide the discount code field
    */
-  discount: boolean;
+  discount?: boolean;
   /**
    * If `true`, show the checkout overlay
    *
    * @docs https://docs.lemonsqueezy.com/help/checkout/checkout-overlay
    */
-  embed: boolean;
+  embed?: boolean;
   /**
    * If `false`, hide the store logo
    */
-  logo: boolean;
+  logo?: boolean;
   /**
    * If `false`, hide the product media
    */
-  media: boolean;
+  media?: boolean;
+}
+
+export interface LemonsqueezyCheckoutPreview {
+  currency_rate: number;
+  currency: string;
+  discount_total_formatted: string;
+  discount_total_usd: number;
+  discount_total: number;
+  subtotal_formatted: string;
+  subtotal_usd: number;
+  subtotal: number;
+  tax_formatted: string;
+  tax_usd: number;
+  tax: number;
+  total_formatted: string;
+  total_usd: number;
+  total: number;
 }
 
 export interface LemonsqueezyProductOptions {
@@ -83,11 +100,11 @@ export interface LemonsqueezyProductOptions {
   /**
    * An array of variant IDs to enable for this checkout. If this is empty, all variants will be enabled
    */
-  enabled_variants: Array<string>;
+  enabled_variants?: Array<string>;
   /**
    * An array of image URLs to use as the product's media
    */
-  media: Array<string>;
+  media?: Array<string>;
   /**
    * A custom name for the product
    */
@@ -144,6 +161,7 @@ export interface LemonsqueezyCheckout {
      * @see https://en.wikipedia.org/wiki/ISO_8601
      */
     expires_at: Date | null;
+    preview: LemonsqueezyCheckoutPreview;
     /**
      * An object containing any overridden product options for this checkout
      */
@@ -179,18 +197,80 @@ export interface LemonsqueezyCheckout {
   id: string;
 }
 
-export interface CreateCheckoutOptions
-  extends SharedLemonsqueezyOptions,
-    Partial<
-      Pick<
-        LemonsqueezyCheckout["attributes"],
-        | "custom_price"
-        | "product_options"
-        | "checkout_options"
-        | "checkout_data"
-        | "expires_at"
-      >
-    > {}
+export interface CreateCheckoutOptions extends SharedLemonsqueezyOptions {
+  /**
+   * An object containing any prefill or custom data to be used in the checkout
+   *
+   * @docs https://docs.lemonsqueezy.com/help/checkout/prefilling-checkout-fields
+   * @docs https://docs.lemonsqueezy.com/help/checkout/passing-custom-data
+   */
+  checkout_data: LemonsqueezyCheckoutData;
+  /**
+   * An object containing checkout options for this checkout
+   */
+  checkout_options?: LemonsqueezyCheckoutOptions;
+  /**
+   * A positive integer in cents representing the custom price of the variant.
+   *
+   * Note: If the product purchased is a subscription, this custom price is used
+   * for all renewal payments. If the subscription's variant changes in the
+   * future (i.e. the customer is moved to a different subscription "tier") the
+   * new variant's price will be used from that moment forward.
+   */
+  custom_price: number;
+  /**
+   * An ISO-8601 formatted date-time string indicating when the checkout expires
+   *
+   * Can be `null` if the checkout is perpetual
+   *
+   * @see https://en.wikipedia.org/wiki/ISO_8601
+   */
+  expires_at?: Date | null;
+  /**
+   * A boolean indicating whether to return a preview of the checkout.
+   *
+   * If `true`, the checkout will include a `preview` object with the checkout preview data.
+   */
+  preview?: boolean;
+  /**
+   * An object containing any overridden product options for this checkout.
+   */
+  product_options: LemonsqueezyProductOptions;
+  /**
+   * The ID of the store this checkout belongs to.
+   */
+  store?: number;
+  /**
+   * The ID of the variant associated with this checkout.
+   *
+   * Note: by default, all variants of the related product will be shown in the checkout, with
+   * your selected variant highlighted. If you want hide to other variants, you can utilise
+   * the `product_options.enabled_variants` option to determine which variant(s) are
+   * displayed in the checkout.
+   */
+  variant?: number;
+}
+
+export interface CreateCheckoutBody {
+  data: {
+    type: LemonsqueezyDataType.checkouts;
+    attributes: CreateCheckoutOptions;
+    relationships?: {
+      store?: {
+        data: {
+          id: number;
+          type: LemonsqueezyDataType.stores;
+        };
+      };
+      variant?: {
+        data: {
+          id: number;
+          type: LemonsqueezyDataType.variants;
+        };
+      };
+    };
+  };
+}
 
 export type CreateCheckoutResult =
   BaseLemonsqueezyResponse<LemonsqueezyCheckout>;

--- a/src/modules/checkout/checkout.types.ts
+++ b/src/modules/checkout/checkout.types.ts
@@ -258,13 +258,13 @@ export interface CreateCheckoutBody {
     relationships: {
       store: {
         data: {
-          id: number;
+          id: string;
           type: LemonsqueezyDataType.stores;
         };
       };
       variant: {
         data: {
-          id: number;
+          id: string;
           type: LemonsqueezyDataType.variants;
         };
       };

--- a/src/modules/checkout/checkout.types.ts
+++ b/src/modules/checkout/checkout.types.ts
@@ -239,7 +239,7 @@ export interface CreateCheckoutOptions extends SharedLemonsqueezyOptions {
   /**
    * The ID of the store this checkout belongs to.
    */
-  store?: number;
+  store: number;
   /**
    * The ID of the variant associated with this checkout.
    *
@@ -248,21 +248,21 @@ export interface CreateCheckoutOptions extends SharedLemonsqueezyOptions {
    * the `product_options.enabled_variants` option to determine which variant(s) are
    * displayed in the checkout.
    */
-  variant?: number;
+  variant: number;
 }
 
 export interface CreateCheckoutBody {
   data: {
     type: LemonsqueezyDataType.checkouts;
-    attributes: CreateCheckoutOptions;
-    relationships?: {
-      store?: {
+    attributes: Omit<CreateCheckoutOptions, "store" | "variant">;
+    relationships: {
+      store: {
         data: {
           id: number;
           type: LemonsqueezyDataType.stores;
         };
       };
-      variant?: {
+      variant: {
         data: {
           id: number;
           type: LemonsqueezyDataType.variants;

--- a/src/modules/checkout/index.ts
+++ b/src/modules/checkout/index.ts
@@ -13,6 +13,7 @@ export type {
   LemonsqueezyCheckout,
   LemonsqueezyCheckoutData,
   LemonsqueezyCheckoutOptions,
+  LemonsqueezyCheckoutPreview,
   LemonsqueezyProductOptions,
   ListAllCheckoutsOptions,
   ListAllCheckoutsResult,

--- a/src/modules/discount/discount.types.ts
+++ b/src/modules/discount/discount.types.ts
@@ -92,7 +92,7 @@ export interface LemonsqueezyDiscount {
     updated_at: Date;
   };
   type: LemonsqueezyDataType.discounts;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllDiscountsOptions extends SharedLemonsqueezyOptions {

--- a/src/modules/file/file.types.ts
+++ b/src/modules/file/file.types.ts
@@ -64,7 +64,7 @@ export interface LemonsqueezyFile {
     version: string;
   };
   type: LemonsqueezyDataType.files;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllFilesOptions extends SharedLemonsqueezyOptions {

--- a/src/modules/licenseKey/licenseKey.types.ts
+++ b/src/modules/licenseKey/licenseKey.types.ts
@@ -82,7 +82,7 @@ export interface LemonsqueezyLicenseKey {
     user_name: string;
   };
   type: LemonsqueezyDataType.license_keys;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllLicenseKeysOptions extends SharedLemonsqueezyOptions {

--- a/src/modules/licenseKeyInstance/licenseKeyInstance.types.ts
+++ b/src/modules/licenseKeyInstance/licenseKeyInstance.types.ts
@@ -40,7 +40,7 @@ export interface LemonsqueezyLicenseKeyInstance {
     updated_at: Date;
   };
   type: LemonsqueezyDataType.license_key_instances;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllLicenseKeyInstancesOptions

--- a/src/modules/order/order.types.ts
+++ b/src/modules/order/order.types.ts
@@ -114,7 +114,7 @@ export interface LemonsqueezyOrder {
     user_name: string;
   };
   type: LemonsqueezyDataType.orders;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllOrdersOptions extends SharedLemonsqueezyOptions {

--- a/src/modules/orderItem/orderItem.types.ts
+++ b/src/modules/orderItem/orderItem.types.ts
@@ -50,7 +50,7 @@ export interface LemonsqueezyOrderItem {
     variant_name: string;
   };
   type: LemonsqueezyDataType.order_items;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllOrderItemsOptions extends SharedLemonsqueezyOptions {

--- a/src/modules/product/product.types.ts
+++ b/src/modules/product/product.types.ts
@@ -88,7 +88,7 @@ export interface LemonsqueezyProduct {
     updated_at: Date;
   };
   type: LemonsqueezyDataType.products;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllProductsOptions extends SharedLemonsqueezyOptions {

--- a/src/modules/store/store.types.ts
+++ b/src/modules/store/store.types.ts
@@ -79,7 +79,7 @@ export interface LemonsqueezyStore {
      */
     url: string;
   };
-  id: string | number;
+  id: string;
   type: LemonsqueezyDataType.stores;
 }
 

--- a/src/modules/subscription/subscription.types.ts
+++ b/src/modules/subscription/subscription.types.ts
@@ -139,7 +139,7 @@ export interface LemonsqueezySubscription {
     variant_name: string;
   };
   type: LemonsqueezyDataType.subscriptions;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllSubscriptionsOptions extends SharedLemonsqueezyOptions {

--- a/src/modules/user/user.types.ts
+++ b/src/modules/user/user.types.ts
@@ -42,7 +42,7 @@ export interface LemonsqueezyUser {
      */
     updatedAt: Date;
   };
-  id: string | number;
+  id: string;
   links: {
     self: string;
   };

--- a/src/modules/variant/variant.types.ts
+++ b/src/modules/variant/variant.types.ts
@@ -136,7 +136,7 @@ export interface LemonsqueezyVariant {
     updated_at: Date;
   };
   type: LemonsqueezyDataType.variants;
-  id: string | number;
+  id: string;
 }
 
 export interface ListAllVariantsOptions extends SharedLemonsqueezyOptions {

--- a/src/shared/shared.actions.ts
+++ b/src/shared/shared.actions.ts
@@ -56,11 +56,20 @@ export async function requestLemonSqueeze<
           }
         : {}),
     });
-    if (!response.ok)
+    if (!response.ok) {
+      const errorsJson = (await response.json()) as {
+        errors: Array<{
+          detail: string;
+          status: number;
+          title: string;
+        }>;
+      };
       throw {
         status: response.status,
         message: response.statusText,
+        errors: errorsJson.errors,
       };
+    }
 
     const json = (await response.json()) as TResponse;
     if (json.errors && json.errors.length > 0) throw json;

--- a/src/shared/shared.actions.ts
+++ b/src/shared/shared.actions.ts
@@ -52,7 +52,7 @@ export async function requestLemonSqueeze<
       method,
       ...(data && method !== "GET"
         ? {
-            body: JSON.stringify(params),
+            body: JSON.stringify(data),
           }
         : {}),
     });

--- a/src/shared/shared.actions.ts
+++ b/src/shared/shared.actions.ts
@@ -12,7 +12,8 @@ import type {
 export async function requestLemonSqueeze<
   TResponse extends
     | BaseLemonsqueezyResponse<any>
-    | PaginatedBaseLemonsqueezyResponse<any>
+    | PaginatedBaseLemonsqueezyResponse<any>,
+  TData extends Record<string, any> = Record<string, any>
 >({
   apiKey,
   apiVersion = "v1",
@@ -24,7 +25,7 @@ export async function requestLemonSqueeze<
   page,
   params,
   path,
-}: LemonsqueezyOptions): Promise<TResponse> {
+}: LemonsqueezyOptions<TData>): Promise<TResponse> {
   try {
     const url = new URL(join(apiVersion, path), baseUrl);
 

--- a/src/shared/shared.types.ts
+++ b/src/shared/shared.types.ts
@@ -11,11 +11,12 @@ export interface SharedLemonsqueezyOptions {
   baseUrl?: string;
 }
 
-export interface LemonsqueezyOptions
-  extends Omit<RequestInit, "body">,
+export interface LemonsqueezyOptions<
+  TData extends Record<string, any> = Record<string, any>
+> extends Omit<RequestInit, "body">,
     SharedLemonsqueezyOptions,
     SharedModuleOptions {
-  data?: Record<string, any>;
+  data?: TData;
   params?: Record<string, any>;
   method?:
     | "CONNECT"


### PR DESCRIPTION
### What's been changed?

 - Updated `LemonsqueezyOptions` to take an optional generic to set the type of the `data` property
 - Fixed multiple checkout types to be optional rather than required
 - Added new `LemonsqueezyCheckoutPreview` type
 - Updated `LemonsqueezyCheckout` to add new `preview` property
	 - Needs documentation comment adding
 - Updated `CreateCheckoutOptions` type to manually write out / type properties
 - Added new `CreateCheckoutBody` type to type the POST request body
 - Improved core error handling

### What still needs to be done

- [x] Update checkout tests
	- [x] Creating a checkout
	- [x] Retrieve a checkout using the newly created one above