### PR TITLE
Change checkout custom data type to key value pairs

### DIFF
--- a/src/modules/checkout/checkout.types.ts
+++ b/src/modules/checkout/checkout.types.ts
@@ -23,7 +23,7 @@ export interface LemonsqueezyCheckoutData {
   /**
    * An object containing any custom data to be passed to the checkout
    */
-  custom?: Array<any>;
+  custom?: { [key: string]: any };
   /**
    * A pre-filled discount code
    */


### PR DESCRIPTION
The custom data needs to be key value pairs as lemon squeezy shows in their docs: https://docs.lemonsqueezy.com/help/checkout/passing-custom-data

```

{
  "meta": {
    "event_name": "order_created",
    "custom_data": {
      "user_id": "123"
    }
  },
  ...
}
```