### PR TITLE
add customer_id to subscription type

### DIFF
--- a/src/modules/subscription/subscription.types.ts
+++ b/src/modules/subscription/subscription.types.ts
@@ -91,6 +91,10 @@ export interface LemonsqueezySubscription {
      */
     store_id: number;
     /**
+     * The ID of the customer this subscription belongs to.
+     */
+    customer_id: number;
+    /**
      * A boolean indicating if the returned subscription object was created within test mode
      */
     test_mode: boolean;


### PR DESCRIPTION
It's currently missing in subscription type.

https://docs.lemonsqueezy.com/api/subscriptions#the-subscription-object