### PR TITLE
Proration configs added to update subscription

### DIFF
--- a/src/modules/subscription/subscription.action.ts
+++ b/src/modules/subscription/subscription.action.ts
@@ -94,7 +94,7 @@ export async function retrieveSubscription(
 export async function updateSubscription(
   options: UpdateSubscriptionOptions & SharedModuleOptions
 ): Promise<UpdateSubscriptionResult> {
-  const { billingAnchor, cancelled, id, pause, productId, variantId, ...rest } =
+  const { billingAnchor, cancelled, id, pause, productId, variantId, invoiceImmediately, disableProrations,  ...rest } =
     options;
 
   return requestLemonSqueeze<UpdateSubscriptionResult>({
@@ -106,6 +106,8 @@ export async function updateSubscription(
           pause,
           product_id: productId,
           variant_id: variantId,
+          invoice_immediately: invoiceImmediately,
+          disable_prorations: disableProrations
         },
         id,
         type: LemonsqueezyDataType.subscriptions,

--- a/src/modules/subscription/subscription.types.ts
+++ b/src/modules/subscription/subscription.types.ts
@@ -224,16 +224,12 @@ export interface UpdateSubscriptionOptions extends SharedLemonsqueezyOptions {
   /**
    * If true, any updates to the subscription will be charged immediately.
    *
-   * Required if `product_id` set
-   *
    * @docs https://docs.lemonsqueezy.com/guides/developer-guide/managing-subscriptions#handling-proration
    */
   invoiceImmediately?: boolean;
   /**
    * If true, any updates to the subscription will be charged immediately but will not be prorated. 
    * Note that this will override the invoice_immediately option if enabled.
-   *
-   * Required if `product_id` set
    *
    * @docs https://docs.lemonsqueezy.com/guides/developer-guide/managing-subscriptions#handling-proration
    */

--- a/src/modules/subscription/subscription.types.ts
+++ b/src/modules/subscription/subscription.types.ts
@@ -221,13 +221,15 @@ export interface UpdateSubscriptionOptions extends SharedLemonsqueezyOptions {
    * @docs https://docs.lemonsqueezy.com/api/variants
    */
   variantId: string;
+  /**
    * If true, any updates to the subscription will be charged immediately.
    *
    * Required if `product_id` set
    *
    * @docs https://docs.lemonsqueezy.com/guides/developer-guide/managing-subscriptions#handling-proration
    */
-  invoiceImmediately?: boolean
+  invoiceImmediately?: boolean;
+  /**
    * If true, any updates to the subscription will be charged immediately but will not be prorated. 
    * Note that this will override the invoice_immediately option if enabled.
    *
@@ -235,7 +237,7 @@ export interface UpdateSubscriptionOptions extends SharedLemonsqueezyOptions {
    *
    * @docs https://docs.lemonsqueezy.com/guides/developer-guide/managing-subscriptions#handling-proration
    */
-  disableProrations?: boolean
+  disableProrations?: boolean;
 }
 
 export type UpdateSubscriptionResult =

--- a/src/modules/subscription/subscription.types.ts
+++ b/src/modules/subscription/subscription.types.ts
@@ -221,6 +221,21 @@ export interface UpdateSubscriptionOptions extends SharedLemonsqueezyOptions {
    * @docs https://docs.lemonsqueezy.com/api/variants
    */
   variantId: string;
+   * If true, any updates to the subscription will be charged immediately.
+   *
+   * Required if `product_id` set
+   *
+   * @docs https://docs.lemonsqueezy.com/guides/developer-guide/managing-subscriptions#handling-proration
+   */
+  invoiceImmediately?: boolean
+   * If true, any updates to the subscription will be charged immediately but will not be prorated. 
+   * Note that this will override the invoice_immediately option if enabled.
+   *
+   * Required if `product_id` set
+   *
+   * @docs https://docs.lemonsqueezy.com/guides/developer-guide/managing-subscriptions#handling-proration
+   */
+  disableProrations?: boolean
 }
 
 export type UpdateSubscriptionResult =


### PR DESCRIPTION
This PR adds two new prorate related  configs ( `invoice_immediately ` and `disable_prorations` 
) to update subscription.

you can find them here https://docs.lemonsqueezy.com/api/subscriptions#update-a-subscription. 