### PR TITLE
Add proration parameters and bump minor version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lemonsqueezy.ts",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "JavaScript / TypeScript SDK for the Lemon Squeezy API",
   "repository": {
     "type": "git",

--- a/src/modules/subscription/subscription.action.ts
+++ b/src/modules/subscription/subscription.action.ts
@@ -94,7 +94,7 @@ export async function retrieveSubscription(
 export async function updateSubscription(
   options: UpdateSubscriptionOptions & SharedModuleOptions
 ): Promise<UpdateSubscriptionResult> {
-  const { billingAnchor, cancelled, id, pause, productId, variantId, ...rest } =
+  const { billingAnchor, cancelled, id, pause, productId, variantId, invoiceImmediately, disableProrations, ...rest } =
     options;
 
   return requestLemonSqueeze<UpdateSubscriptionResult>({
@@ -106,6 +106,8 @@ export async function updateSubscription(
           pause,
           product_id: productId,
           variant_id: variantId,
+          invoice_immediately: invoiceImmediately,
+          disable_prorations: disableProrations,
         },
         id,
         type: LemonsqueezyDataType.subscriptions,

--- a/src/modules/subscription/subscription.types.ts
+++ b/src/modules/subscription/subscription.types.ts
@@ -221,6 +221,21 @@ export interface UpdateSubscriptionOptions extends SharedLemonsqueezyOptions {
    * @docs https://docs.lemonsqueezy.com/api/variants
    */
   variantId: string;
+  /**
+   * If `true`, any updates to the subscription will be charged immediately. 
+   * A new prorated invoice will be generated and payment attempted. 
+   * Defaults to `false`. Note that this will be overridden by the `disableProrations` option if used.
+   * 
+   * @docs https://docs.lemonsqueezy.com/api/subscriptions#update-a-subscription
+   */
+  invoiceImmediately?: boolean;
+  /**
+   * If `true`, no proration will be charged and the customer will simply be charged the new price at the next renewal. 
+   * Defaults to `false`. Note that this will override the `invoiceImmediately` option if used.
+   * 
+   * @docs https://docs.lemonsqueezy.com/api/subscriptions#update-a-subscription
+   */
+  disableProrations?: boolean;
 }
 
 export type UpdateSubscriptionResult =


### PR DESCRIPTION
This pull request adds two new parameters to the `updateSubscription` function: `invoiceImmediately` and `disableProrations`. These parameters allow for more flexibility when updating a subscription and are documented in the Lemon Squeezy API. Additionally, the minor version number of the `lemonsqueezy.ts` SDK has been bumped from `0.1.7` to `0.1.8`.